### PR TITLE
feat: enhancing report results processing

### DIFF
--- a/utils/io.py
+++ b/utils/io.py
@@ -32,4 +32,4 @@ def writeResultToCSV(result, filename):
     outfile = './results/' + filename + '_' + timestamp + '.csv'
     print('writeResultToCSV: ' + outfile)
     df = pd.DataFrame(result)
-    df.to_csv(outfile)
+    df.to_csv(outfile, index=False)


### PR DESCRIPTION
Closes the below issues:
#16 - Added issue comment body as part of comments to be processed
#17 - Remove row index number column from output CSV
#18 - Adding HTML url of issue.

Sample output below of updated result processing:

issueID | issueURL_API | issueURL_HTML | commentLine | commentURL | category
-- | -- | -- | -- | -- | --
808389782 | https://api.github.com/repos/nrontsis/PILCO/issues/57 | https://github.com/nrontsis/PILCO/pull/57 | using SCREEN_NAME allowed 2 3 time speedup policy optimization longest   step pendulum v0 environment this work pre compiling tensorflow graph first   execution function please let know need careful speedup analysis | https://github.com/nrontsis/PILCO/pull/57 | Solution Discussion

- Issue comments (descriptions) now being considered as part of the corpus of comments to be categorized.
- Index column no longer visible
- Added new `issueURL_HTML`
  - Note for issue body comment (description), the `commentUR`  is just the `issueURL_HTML` itself as I don't see a way that GitHub readily gives you the specific issue's body comment (description) URL like the one you linked in issue #16 
