### PR TITLE
fix: updating README and run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,15 @@ Python script to mine for GitHub issues + comments and classify them.
 ## Setup:
 1) Ensure Python `3.9.1` and corrosponding pip `3.9` are installed
 2) Install requirements: `pip3.9 install -r requirements.txt`
-   - Part of the script also relies on downloading stop word dictionaries.
-   - Download `nltk` stop words if the script throws and error by uncommenting
-     `nltk.download('wordnet')` and `nltk.download('stopwords'` in `commentProcessor.py`
-3) Add a GitHub Personal Access Token in the access token file: `access_token.json`. Replace `<YOUR_GITHUB_PERSONAL_ACCESS_TOKEN>` with your token.
+3) Download nltk stop word packages (only need to do it once per environment)
+   - Download `nltk` stop words packages `wordnet` and `stopwords` via the python terminal
+   ```aidl
+    > import nltk
+    > nltk.download('wordnet')
+    > nltk.download('stopwords')
+    ```
+    - If you run intl SSL error, make sure python ssl certificates are installed: `bash /Applications/Python\ 3.9/Install\ Certificates.command `
+4) Add a GitHub Personal Access Token in the access token file: `access_token.json`. Replace `<YOUR_GITHUB_PERSONAL_ACCESS_TOKEN>` with your token.
    
 Instructions on how to create a GitHub Personal Access Token: https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token
  
@@ -41,7 +46,7 @@ optional arguments:
 ### Usage:
 Run `python3.9 mine-issues.py <QUERY>` with the following optional parameters:
 
-`-i` or `--interface`: will cause the script to trigger the interactive CLI see in the screenshot above.
+`-i` or `--interface`: will cause the script to trigger the interactive CLI and ignore all other params. See screenshot above of the interface.
 
 `-v` or `--verbose`: will print out extra logging such as printing out the entire result object in neat JSON format.
 

--- a/config/.gitignore
+++ b/config/.gitignore
@@ -1,1 +1,0 @@
-access_token.json

--- a/requirements.txt
+++ b/requirements.txt
@@ -64,7 +64,6 @@ pytz==2020.5
 pyzmq==20.0.0
 qtconsole==5.0.1
 QtPy==1.9.0
-ratelimit==2.2.1
 regex==2020.11.13
 requests==2.25.1
 scikit-learn==0.24.0


### PR DESCRIPTION
fix: tested run instructions on new env and updating readme

- Test ran the README instructions on a completely new environment with the correct python version downloaded
- Updating minor test instructions
- Updating minor package requirements