### PR TITLE
chore: updating command line argument name

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ There are two ways to run this program, either through the interactive command l
 
 Below is the `-h` help/man page:
 ```aidl
-usage: mine-issues.py [-h] [-i] [-v] [-m MAX_RESULTS] [-s SORT_BY] [-p PREFIX_FILENAME] query
+Usage: mine-issues.py [-h] [-i] [-v] [-m MAX_RESULTS] [-s SORT_BY] [-p PREFIX_FILENAME] query
 
 positional arguments:
   query
 
 optional arguments:
   -h, --help            show this help message and exit
-  -i, --interface       **toggle the interactive CLI**
+  -i, --interactive       **toggle the interactive CLI**
   -v, --verbose         print additional logs
   -m MAX_RESULTS, --max-results MAX_RESULTS
                         (int) max results to query

--- a/mine-issues.py
+++ b/mine-issues.py
@@ -27,7 +27,7 @@ parser = argparse.ArgumentParser()
 
 # Interface option, if true we toggle the interface below.
 # If false, we just grab the params from argparser result.
-parser.add_argument('-i', '--interface', action='store_true',
+parser.add_argument('-i', '--interactive', action='store_true',
 					help="**toggle the interactive CLI**")
 
 parser.add_argument('query')
@@ -55,7 +55,7 @@ args = parser.parse_args()
 params = {}
 
 # If user entered the '-i' or '--interface' option, trigger the pyinquirer interactive interface.
-if args.interface:
+if args.interactive:
 	params = InitializeSearchInterface(args.query)
 else:
 	params['q'] = args.query


### PR DESCRIPTION
Update `--interface` to `--interactive` for the interactive CLI toggle parameter.