### PR TITLE
removing issue description classification from result

### DIFF
--- a/mine-issues.py
+++ b/mine-issues.py
@@ -209,25 +209,6 @@ for r in MATCHED_RESULTS:
 		"issueURL_HTML": r['html_url']
 	})
 
-	# Also add each issue's body (description/first comment) to the
-	# comment corpus array to be processed as well.
-	issue_body = r['body'] or ""
-	# Also check for issue's description for any CODE blocks to be tokenized.
-	issue_body = re.sub('```([^`]*)```|`([^`]*)`', 'CODE', issue_body)
-	issue_body_lines = issue_body.splitlines()
-	for line in issue_body_lines:
-		# Strip away any new lines
-		line = line.strip('\n')
-		line = line.strip('\t')
-		if line:
-			CORPUS.append({
-				"issueID": r['id'],
-				"issueURL_API": r['url'],
-				"issueURL_HTML": r['html_url'],
-				"commentLine": processComment(line),
-				"commentURL": r['html_url'] # Same as issue html url
-			})
-
 print("\n")
 
 # For each of the comment_url in the list to query, query for all the comments


### PR DESCRIPTION
Closes #47 

Remove the block of code where it adds issue description to the list of comments to be classified.
Before/After CSV result files attached.

[results__CLASSIFIED_COMMENTS_BEFORE.csv](https://github.com/ponder-lab/GitHub-Issue-Classifier/files/6831505/results__CLASSIFIED_COMMENTS_BEFORE.csv)
[results__CLASSIFIED_COMMENTS_AFTER.csv](https://github.com/ponder-lab/GitHub-Issue-Classifier/files/6831506/results__CLASSIFIED_COMMENTS_AFTER.csv)
