### PR TITLE
fix: omitting dependabot login from classification

### DIFF
--- a/utils/githubAPI.py
+++ b/utils/githubAPI.py
@@ -70,7 +70,7 @@ def gitHubCommentAPI(issues):
 
         # For each non-bot comment, split up each sentence and append into CORPUS array above.
         for comment in comment_data:
-            if (comment["user"]["type"] != "Bot"):
+            if (comment["user"]["type"] != "Bot" and comment["user"]["login"] != "dependabot[bot]"):
 
                 # Tokenize CODE before splitting lines to prevent random code formatted lines
                 # to throw error and skew the results.


### PR DESCRIPTION
Original issue was fixed by https://github.com/ponder-lab/GitHub-Issue-Classifier/pull/50
Adding additional check for dependabot's account name to the check to remove bot comments

Closes #48 